### PR TITLE
fix: cfs index error

### DIFF
--- a/cloud/endpoints.py
+++ b/cloud/endpoints.py
@@ -92,15 +92,18 @@ def allow_cors(fn):
 # route all from base path (usually APP_ID, name or alias)
 @allow_cors
 def handle_all(request):
-    path = request.path.split('/')
-    root = _STRIP(path)[0]
-    if root == 'auth':
-        return handle_auth(request)
-    elif root == 'meta':
-        return handle_meta(request)
-    elif root == 'data':
-        return handle_data(request)
-    return Response(f'Not Found @ {path}', 404)
+    try:
+        path = request.path.split('/')
+        root = _STRIP(path)[0]
+        if root == 'auth':
+            return handle_auth(request)
+        elif root == 'meta':
+            return handle_meta(request)
+        elif root == 'data':
+            return handle_data(request)
+        return Response(f'Not Found @ {path}', 404)
+    except Exception as err:
+        return Response(f'Unhandled Server Error: {err}', 500)
 
 
 @allow_cors

--- a/local_server.py
+++ b/local_server.py
@@ -1,7 +1,30 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2020 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
 from flask import Flask, request
 from . import main
 
 app = Flask(__name__)
+app.logger.setLevel(logging.DEBUG)
 
 
 @app.route('/<path:text>', methods=['GET', 'POST'])

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -39,6 +39,7 @@ test_all() {
 }
 
 run_local() {
+    export FLASK_ENV=development
     export FLASK_APP=app.local_server
     flask run --host=0.0.0.0 --port=9009
 }


### PR DESCRIPTION
Cloud Firestore supports "single field indexing" automatically. However, any more complex queries _must_ have an index built for them. If not an error is raised at query time.

These are the query operations that do not require the creation of new indices.

https://cloud.google.com/firestore/docs/concepts/index-overview#queries_supported_by_single-field_indexes


However, since we implement some of the API in the cloud function layer (here) rather than in the database in order to enforce the Logiak RBAC, we implement some functionality that would normally require an index in memory at function runtime. If you have very large queries, you may need to increase the amount of memory available to the function runtime, as the following operations hold all results in memory before returning them to the caller. 

`orderBy`
`startAt`
`endAt`

The reason for this, is that we can only pull 10 records at a time by UUID for which a caller has access. We do this for all matching records using the requested filter like:
```
matches = (
  for id_chunk -> List[10] in all_valid_ids:
    SELECT * from {type} where uuid in id_chunk AND {where filter from query} 
)
matches -> sorted(matches, order)
matches -> matches[slice on startAt/endAt]
```