### PR TITLE
fix: do small query outside of generator to trigger index errors

### DIFF
--- a/cloud/data.py
+++ b/cloud/data.py
@@ -68,6 +68,7 @@ def resolve(user_id, path: List, cfs: fb_utils.Firestore, data=None) -> Response
                 if data:
                     # validate outside of the generator
                     data = StructuredQuery(**data)
+                    _validate_query(cfs, _type, data)
                     _response_generator = _query(cfs, user_id, _type, data)
                 else:
                     _response_generator = _query(cfs, user_id, _type, None)
@@ -113,6 +114,20 @@ def _get(
     _doc = cfs.ref(full_path=uri).get()
     if _doc:
         return json.dumps(_doc.to_dict(), sort_keys=True)
+
+
+def _validate_query(
+    cfs: fb_utils.Firestore,
+    _type: str,
+    structured_query: StructuredQuery = None
+) -> bool:
+    uri = f'{APP_ID}/data/{_type}'
+    query_ = cfs.ref(path=uri)
+    query_ = structured_query.filter(query_).limit(1).stream()
+    for doc in query_:
+        # consume from the generator to trigger any errors:
+        pass
+    return True
 
 
 def _query(

--- a/cloud/meta.py
+++ b/cloud/meta.py
@@ -50,16 +50,20 @@ def as_json_response(obj) -> Response:
 
 def resolve(path, rtdb: fb_utils.RTDB) -> Response:
     path = _STRIP(path)
-    if path[0] == 'schema':
-        if len(path) == 2:
-            return as_json_response(_meta_list_schemas(rtdb, path[1]))
-        if len(path) == 3:
-            return as_json_response(_meta_schema(rtdb, path[1], path[2]))
-    elif path[0] == 'app':
-        if len(path) < 2:
-            return as_json_response(_meta_info(rtdb))
-        else:
-            return as_json_response(_meta_app(rtdb, path[1], path[2]))
+    try:
+        if path[0] == 'schema':
+            if len(path) == 2:
+                return as_json_response(_meta_list_schemas(rtdb, path[1]))
+            if len(path) == 3:
+                return as_json_response(_meta_schema(rtdb, path[1], path[2]))
+        elif path[0] == 'app':
+            if len(path) < 2:
+                return as_json_response(_meta_info(rtdb))
+            else:
+                return as_json_response(_meta_app(rtdb, path[1], path[2]))
+    except IndexError:
+        # could not parse args
+        pass
     return Response(f'Not Found @ {path}', 404)
 
 


### PR DESCRIPTION
In GCP, Responses are sent outside the scope of our functions to a surrounding WSGI layer. If you pass a generator to a response, for the purpose of streaming content, any errors in the generator will not be handled by our function code. In this case we want to trigger a "missing index" exception from CloudFirestore before we attempt to stream the response.